### PR TITLE
Add mesa dependency

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,7 +4,7 @@
 , xorg, alsaLib, libbsd, libopus, openssl, libva, pango, cairo, libuuid, nspr
 , nss, cups, expat, atk, at-spi2-atk, gtk3, gdk-pixbuf, libsecret, systemd
 , pulseaudio, libGL, dbus, libnghttp2, libidn2, libpsl, libkrb5, openldap
-, rtmpdump, libinput
+, rtmpdump, libinput, mesa
 
 , enableDiagnostics ? false, extraClientParameters ? []
 , shadowChannel ? "prod", desktopLauncher ? true }:
@@ -66,6 +66,7 @@ in stdenv.mkDerivation rec {
     libkrb5
     openldap
     rtmpdump
+    mesa
   ];
 
   # Mandatory libraries for the runtime


### PR DESCRIPTION
Recent changes in nixpkgs (though I haven't identified which one) means that the mesa dependency must be explicitly defined.

On nixpkgs-unstable, you get the following error currently:
```
# nix-build  -E 'let pkgs = import <nixpkgs> { }; in pkgs.callPackage ./. { }'
......
       > autoPatchelfHook could not satisfy dependency libgbm.so.1 wanted by /nix/store/pr4lay9m9mkbh61hjy0bbp8lnhraa8wc-shadow-prod-5.0.919/opt/shadow-prod/shadow
       > Add the missing dependencies to the build inputs or set autoPatchelfIgnoreMissingDeps=true
       For full logs, run 'nix log /nix/store/3zkjyxi2ghwv6l58hvm8061hv5alaghj-shadow-prod-5.0.919.drv'.
```

This commit fixes that error.